### PR TITLE
Manually block a user/ip

### DIFF
--- a/lib/log_logins.rb
+++ b/lib/log_logins.rb
@@ -36,6 +36,14 @@ module LogLogins
     Event.log('Unblocked', nil, nil, ip)
   end
 
+  def self.block_user(user)
+    Event.log('Blocked', nil, user, nil)
+  end
+
+  def self.block_ip(ip)
+    Event.log('Blocked', nil, nil, ip)
+  end
+
   private
 
   def self.blocked!(username, user, ip, options = {})


### PR DESCRIPTION
Hi, fab little gem - hope you don't mind me submitting a pull request!

This adds the ability to manually insert a block for a particular user or IP address eg. for a temporary administrative ban.